### PR TITLE
Add support for strikethrough, inline code, code blocks and underscore syntax variants

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -3,8 +3,10 @@ import {
   DefaultColorDecorationType, HideDecorationType, XxlTextDecorationType, XlTextDecorationType, LTextDecorationType,
 } from './decorations';
 
-const boldRegex = /\*{2}((?=[^\s*]).*?[^\s*])\*{2}/g;
-const italicRegex = /(?<!\*)\*((?=[^\s*]).*?[^\s*])\*(?!\*)/g;
+const boldRegex = /(\*{2}|_{2})((?=[^\s*_]).*?[^\s*_])(\1)/g;
+const italicRegex = /(?<!\*|_)(\*|_)((?=[^\s*_]).*?[^\s*_])(\1)(?!\*|_)/g;
+const strikethroughRegex = /(?<!~)(~{2})((?=[^\s~]).*?[^\s~])(~{2})(?!~)/g;
+const inlineCodeRegex = /(`)((?=[^\s`]).*?[^\s`])(`)/g;
 const hRegex = /^[ \t]*#{1,6}([ \t].*|$)/gm;
 const h1Regex = /^[ \t]*#{1}([ \t].*|$)/gm;
 const h2Regex = /^[ \t]*#{2}([ \t].*|$)/gm;
@@ -44,6 +46,8 @@ export class Decorator {
     const hiddenRanges = [];
     hiddenRanges.push(...this.getTogglableSymmetricRanges(documentText, boldRegex, 2));
     hiddenRanges.push(...this.getTogglableSymmetricRanges(documentText, italicRegex, 1));
+    hiddenRanges.push(...this.getTogglableSymmetricRanges(documentText, strikethroughRegex, 2));
+    hiddenRanges.push(...this.getTogglableSymmetricRanges(documentText, inlineCodeRegex, 1));
     hiddenRanges.push(...this.getHeadingHidingRanges(documentText));
     this.activeEditor.setDecorations(this.hideDecorationType, hiddenRanges);
 


### PR DESCRIPTION
Hi,

I found this project yesterday and have decided to move to VSCodium for my Markdown editing. I have made a few adjustments to the version that I will use and was wondering if you would like them upstream.

I have added support for strikethrough and inline code syntax hiding along with the underscore variants of the bold and italics syntax. Additionally, I adjusted the `getTogglableSymmetricRanges` function to rely on regex capture groups (the first and last of each expression) to allow for variable length ranges. I then added code block support (resolving #6).

Feel free to reject these changes of course, just thought I'd check.

Thanks
(This is my first PR BTW, I hope I did it correctly.)